### PR TITLE
fix(address fields): Show and populate address fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="1.1.28"></a>
+## [1.1.28](https://github.com/bullhorn/novo-elements/compare/v1.1.27...v1.1.28) (2016-11-10)
+
+
+### Features
+
+* **Multipicker:** Adding a multipicker component ([e9bb57a](https://github.com/bullhorn/novo-elements/commit/e9bb57a))
+
+
+
 <a name="1.1.27"></a>
 ## [1.1.27](https://github.com/bullhorn/novo-elements/compare/v1.1.26...v1.1.27) (2016-11-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+<a name="1.1.27"></a>
+## [1.1.27](https://github.com/bullhorn/novo-elements/compare/v1.1.26...v1.1.27) (2016-11-10)
+
+
+
 <a name="1.1.26"></a>
 ## [1.1.26](https://github.com/bullhorn/novo-elements/compare/v1.1.25...v1.1.26) (2016-11-02)
 

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -47,7 +47,7 @@ module.exports = {
     // See: http://webpack.github.io/docs/configuration.html#entry
     entry: {
         'polyfills': './demo/polyfills.browser.js',
-        'vendor': './demo/vendor.browser.js',
+        'deps': './demo/vendor.browser.js',
         'demo': './demo/main.browser.js',
         'lib': [`src/${METADATA.name}`]
     },
@@ -165,7 +165,7 @@ module.exports = {
         // See: https://webpack.github.io/docs/list-of-plugins.html#commonschunkplugin
         // See: https://github.com/webpack/docs/wiki/optimization#multi-page-app
         new webpack.optimize.CommonsChunkPlugin({
-            name: ['polyfills', 'vendor', 'lib'].reverse()
+            name: ['polyfills', 'deps', 'lib'].reverse()
         }),
 
         // Plugin: CopyWebpackPlugin

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -39,12 +39,12 @@ module.exports = webpackMerge(commonConfig, {
         // Specifies the name of each output file on disk.
         // IMPORTANT: You must not specify an absolute path here!
         // See: http://webpack.github.io/docs/configuration.html#output-filename
-        filename: '[name].[chunkhash].bundle.js',
+        filename: '[name].[chunkhash].js',
 
         // The filename of the SourceMaps for the JavaScript files.
         // They are inside the output.path directory.
         // See: http://webpack.github.io/docs/configuration.html#output-sourcemapfilename
-        sourceMapFilename: '[name].[chunkhash].bundle.map',
+        sourceMapFilename: '[name].[chunkhash].map',
 
         // The filename of non-entry chunks as relative path
         // inside the output.path directory.

--- a/demo/app/App.routes.js
+++ b/demo/app/App.routes.js
@@ -30,7 +30,8 @@ import {
     TipWellDemoComponent,
     TableDemoComponent,
     FormDemoComponent,
-    CategoryDropdownDemoComponent
+    CategoryDropdownDemoComponent,
+    MultiPickerDemoComponent
 } from './../pages/elements/all';
 
 export const routes:Routes = [
@@ -55,6 +56,7 @@ export const routes:Routes = [
     { path: 'loading', component: LoadingDemoComponent, title: 'Loading', section: 'components' },
     { path: 'dropdown', component: DropdownDemoComponent, title: 'Dropdown', section: 'components' },
     { path: 'picker', component: PickerDemoComponent, title: 'Picker', section: 'components' },
+    { path: 'multi-picker', component: MultiPickerDemoComponent, title: 'MultiPicker', section: 'components' },
     { path: 'chips', component: ChipsDemoComponent, title: 'Chips', section: 'components' },
     { path: 'select', component: SelectDemoComponent, title: 'Select', section: 'components' },
     { path: 'tabs', component: TabsDemoComponent, title: 'Tabs', section: 'components' },

--- a/demo/novo-elements-demo.module.js
+++ b/demo/novo-elements-demo.module.js
@@ -36,7 +36,8 @@ import {
     SlidesDemoComponent,
     EditorDemoComponent,
     TipWellDemoComponent,
-    CategoryDropdownDemoComponent
+    CategoryDropdownDemoComponent,
+    MultiPickerDemoComponent
 } from './pages/elements/all';
 import { UtilsDemoComponent } from './pages/utils/utils/UtilsDemo';
 import { PipesDemoComponent } from './pages/utils/pipes/PipesDemo';
@@ -93,7 +94,8 @@ import { NovoElementsModule, FormUtils } from './../src/novo-elements';
         StatusCell,
         ExtraDetails,
         CustomPickerResults,
-        CategoryDropdownDemoComponent
+        CategoryDropdownDemoComponent,
+        MultiPickerDemoComponent
     ],
     imports: [
         BrowserModule,

--- a/demo/pages/elements/all.js
+++ b/demo/pages/elements/all.js
@@ -17,6 +17,7 @@ export * from './drawer/DrawerDemo';
 export * from './dragula/DragulaDemo';
 export * from './slides/SlidesDemo';
 export * from './picker/PickerDemo';
+export * from './multi-picker/MultiPickerDemo';
 export * from './chips/ChipsDemo';
 export * from './calendar/CalendarDemo';
 export * from './editor/EditorDemo';

--- a/demo/pages/elements/multi-picker/MultiPickerDemo.js
+++ b/demo/pages/elements/multi-picker/MultiPickerDemo.js
@@ -1,0 +1,70 @@
+// NG2
+import { Component } from '@angular/core';
+// APP
+import BasicMultiPicker from './templates/BasicMultiPickerDemo.html';
+import { ChecklistPickerResults } from './../../../../src/novo-elements';
+
+const template = `
+<div class="container">
+    <h1>MultiPicker <small><a target="_blank" href="https://github.com/bullhorn/novo-elements/blob/master/src/elements/multi-picker">(source)</a></small></h1>
+    <p>The multipicker element (<code>multipicker</code>) represents a control that presents a menu of options of multiple types. The options
+    within are set by the <code>source</code> attribute. Options can be pre-selected for the user using the <code>ngModel</code>
+    attribute. Multipicker is the multi-category version of <code>chips</code></p>.
+
+    <br/>
+
+    <h5>Basic Examples</h5>
+    <p>
+        By clicking on the <code>multi-picker</code> element, the options list will be displayed.  Select any of the options
+        by clicking on the item in the list.  The value selected will be added to the list of selected values.
+    </p>
+    <div class="example chips-demo">${BasicMultiPicker}</div>
+    <code-snippet [code]="BasicMultiPicker"></code-snippet>
+</div>
+`;
+
+@Component({
+    selector: 'chips-demo',
+    template: template
+})
+export class MultiPickerDemoComponent {
+    constructor() {
+        this.BasicMultiPicker = BasicMultiPicker;
+
+        this.placeholder = 'Select...';
+        this.value = { states: ['Alabama'], collaborators: [1, 2, 3, 4] };
+        this.types = ['states', 'collaborators'];
+
+        let states = ['Alabama', 'Alaska', 'Arizona', 'Arkansas', 'California', 'Colorado', 'Connecticut', 'Delaware', 'Florida', 'Georgia', 'Hawaii', 'Idaho', 'Illinois', 'Indiana', 'Iowa', 'Kansas', 'Kentucky', 'Louisiana', 'Maine', 'Maryland', 'Massachusetts', 'Michigan', 'Minnesota', 'Mississippi', 'Missouri', 'Montana', 'Nebraska', 'Nevada', 'New Hampshire', 'New Jersey', 'New Mexico', 'New York', 'North Dakota', 'North Carolina', 'Ohio', 'Oklahoma', 'Oregon', 'Pennsylvania', 'Rhode Island', 'South Carolina', 'South Dakota', 'Tennessee', 'Texas', 'Utah', 'Vermont', 'Virginia', 'Washington', 'West Virginia', 'Wisconsin', 'Wyoming'];
+        let collaborators = [{
+            id: 1,
+            firstName: 'Brian',
+            lastName: 'Kimball'
+        }, {
+            id: 2,
+            firstName: 'Josh',
+            lastName: 'Godi'
+        }, {
+            id: 3,
+            firstName: 'Alec',
+            lastName: 'Sibilia'
+        }, {
+            id: 4,
+            firstName: 'Kameron',
+            lastName: 'Sween'
+        }];
+        this.static = {
+            options: [
+                { type: 'collaborators', data: collaborators, format: '$firstName $lastName', field: 'id' },
+                { type: 'states', data: states }
+            ],
+            resultsTemplate: ChecklistPickerResults
+        };
+        this.formatted = {
+            format: '$firstName $lastName',
+            options: collaborators
+        };
+    }
+    onChanged() {
+    }
+}

--- a/demo/pages/elements/multi-picker/templates/BasicMultiPickerDemo.html
+++ b/demo/pages/elements/multi-picker/templates/BasicMultiPickerDemo.html
@@ -1,0 +1,9 @@
+<div class="selected-value">Selected States: <span *ngFor="let item of value.states">{{item}} </span>
+    Selected Collaborators: <span *ngFor="let item of value.collaborators">{{item}} </span></div>
+<multi-picker
+    [source]="static"
+    [placeholder]="placeholder"
+    [types]="types"
+    [(ngModel)]="value"
+    (changed)="onChanged($event)">
+</multi-picker>

--- a/demo/pages/elements/picker/PickerDemo.js
+++ b/demo/pages/elements/picker/PickerDemo.js
@@ -37,9 +37,7 @@ const template = `
     <p>The picker element (<code>input[picker]</code>) represents a control that presents a menu of options. The options
     within are set by the <code>items</code> attribute. Options can be pre-pickered for the user using the <code>value</code>
     attribute.</p>
-
     <br/>
-
     <h5>Basic Examples</h5>
     <p>
         By clicking on the <code>input</code> element, the options list will be displayed.  picker any of the options
@@ -47,7 +45,6 @@ const template = `
     </p>
     <div class="example picker-demo">${BasicPickerDemoTpl}</div>
     <code-snippet [code]="BasicPickerDemoTpl"></code-snippet>
-
     <h5>Async Examples</h5>
     <p>
         By clicking on the <code>input</code> element, the options list will be displayed.  picker any of the options
@@ -55,7 +52,6 @@ const template = `
     </p>
     <div class="example picker-demo">${AsyncPickerDemoTpl}</div>
     <code-snippet [code]="AsyncPickerDemoTpl"></code-snippet>
-
     <h5>Formated Picker Examples</h5>
     <p>
         By clicking on the <code>input</code> element, the options list will be displayed.  picker any of the options
@@ -63,7 +59,6 @@ const template = `
     </p>
     <div class="example picker-demo">${FormattedPickerDemoTpl}</div>
     <code-snippet [code]="FormattedPickerDemoTpl"></code-snippet>
-
     <h5>Custom Picker Examples</h5>
     <p>
         By clicking on the <code>input</code> element, the options list will be displayed.  picker any of the options

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "novo-elements",
-  "version": "1.1.27",
+  "version": "1.1.28",
   "description": "Bullhorn's NOVO Element Repository for Angular 2",
   "scripts": {
     "clean": "node_modules/.bin/del coverage lib dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "novo-elements",
-  "version": "1.1.26",
+  "version": "1.1.27",
   "description": "Bullhorn's NOVO Element Repository for Angular 2",
   "scripts": {
     "clean": "node_modules/.bin/del coverage lib dist",

--- a/src/elements/category-dropdown/CategoryDropdown.scss
+++ b/src/elements/category-dropdown/CategoryDropdown.scss
@@ -70,9 +70,10 @@ novo-category-dropdown {
                 }
             }
 
-            i.bhi-search, i.bhi-times {
+            i.bhi-search,
+            i.bhi-times {
                 position: absolute;
-                top: 5px;
+                bottom: 8px;
                 right: 5px;
                 color: #aaaaaa;
                 font-size: 1em;
@@ -115,6 +116,7 @@ novo-category-dropdown {
             > novo-tab {
                 height: 40px;
                 min-height: 40px;
+
                 > .novo-tab-link {
                     max-width: 100%;
                     height: 100%;
@@ -135,7 +137,8 @@ novo-category-dropdown {
             cursor: pointer;
             font-size: 0.9em;
 
-            &:hover, &:focus {
+            &:focus,
+            &:hover {
                 background: lighten($light, 10%);
                 color: darken($light, 55%);
 
@@ -172,7 +175,7 @@ novo-category-dropdown {
         align-items: flex-end;
 
         .dropdown-container {
-            right: 0px;
+            right: 0;
         }
     }
 }

--- a/src/elements/chips/Chips.js
+++ b/src/elements/chips/Chips.js
@@ -78,7 +78,7 @@ export class NovoChipElement {
             </novo-picker>
         </div>
         <i class="bhi-search"></i>
-        <label class="clear-all" *ngIf="items.length" (click)="clearValue()"><i class="bhi-times"></i> CLEAR ALL</label>
+        <label class="clear-all" *ngIf="items.length" (click)="clearValue()">CLEAR ALL <i class="bhi-times"></i></label>
    `,
     host: {
         '[class.with-value]': 'items.length > 0'

--- a/src/elements/chips/_Chips.scss
+++ b/src/elements/chips/_Chips.scss
@@ -21,6 +21,7 @@ entity-chips {
     &.selected,
     &.selected:hover {
         border-bottom: 1px solid $positive;
+
         & + i {
             color: $positive;
         }
@@ -33,13 +34,14 @@ entity-chips {
         justify-content: space-between;
         background: #EEEEEE;
         border-radius: 4px;
-        padding: .5em .75em;
+        padding: 0.5em 0.75em;
         margin-right: 5px;
         margin-bottom: 5px;
         width: auto;
         max-width: 180px;
         border: 1px solid transparent;
         transition: all 200ms ease-in-out;
+
         span {
             color: darken(#eee, 45%);
             vertical-align: middle;
@@ -49,24 +51,30 @@ entity-chips {
             text-overflow: ellipsis;
             display: flex;
             align-items: center;
+
             i {
                 font-size: 0.8em;
+
                 &:before {
                     vertical-align: baseline !important;
                 }
             }
         }
+
         i.bhi-close {
             margin-left: 10px;
             cursor: pointer;
             color: darken(#eee, 15%);
+
             &:before {
                 vertical-align: baseline;
             }
+
             &:hover {
                 color: darken(#eee, 35%);
             }
         }
+
         &.selected {
             border: 1px solid $positive;
         }
@@ -74,11 +82,13 @@ entity-chips {
 
     .chip-input-container {
         flex-grow: 4;
+
         input {
             padding-top: 0;
             border: none;
             background: transparent;
             width: 100%;
+
             &:focus {
                 outline: none;
             }
@@ -119,6 +129,7 @@ entity-chips {
         position: absolute;
         top: 5px;
         right: 0;
+        font-size: 1.2em;
     }
 }
 
@@ -191,6 +202,7 @@ entity-chips {
             novo-list-item {
                 flex: 0 0;
                 transition: background-color 250ms;
+
                 & > div {
                     width: 100%;
                 }
@@ -205,6 +217,7 @@ entity-chips {
 
                 item-content {
                     flex-flow: row wrap;
+
                     & > * {
                         flex: 0 0 33%;
                         white-space: nowrap;
@@ -213,33 +226,34 @@ entity-chips {
             }
         }
 
+        .error-results,
         .no-recents,
-        .null-results,
-        .error-results {
+        .null-results {
             text-align: center;
             padding: 1em 0 4em;
+
             > i {
                 font-size: 3em;
-                margin: .5em;
+                margin: 0.5em;
                 color: rgba(0, 0, 0, .3);
             }
 
-            > h4,
+             > h4,
             > p {
                 margin: 0;
                 max-width: none;
                 padding: 0;
             }
+
             > h4 {
                 font-weight: 500;
             }
-            > p {
 
-            }
+            > p {}
         }
 
         section {
-            box-shadow: .1em .1em 1em rgba(0, 0, 0, 0.25);
+            box-shadow: 0.1em 0.1em 1em rgba(0, 0, 0, 0.25);
             z-index: 9;
             position: absolute;
             width: 100%;

--- a/src/elements/chips/_Chips.scss
+++ b/src/elements/chips/_Chips.scss
@@ -119,15 +119,15 @@ entity-chips {
         align-items: center;
 
         i {
-            font-size: 0.6rem;
+            font-size: 0.7rem;
             padding-bottom: 2px;
-            margin-right: 5px;
+            margin-left: 5px;
         }
     }
 
     i.bhi-search {
         position: absolute;
-        top: 5px;
+        bottom: 8px;
         right: 0;
         font-size: 1.2em;
     }

--- a/src/elements/form/_Form.scss
+++ b/src/elements/form/_Form.scss
@@ -53,6 +53,7 @@ novo-form {
 
                     &.disabled {
                         pointer-events: none;
+
                         input {
                             &::-webkit-input-placeholder {
                                 color: $light !important;
@@ -64,7 +65,7 @@ novo-form {
                         }
 
                         chips {
-                            border-bottom: 1px dashed $light !important;;
+                            border-bottom: 1px dashed $light !important;
 
                             chip {
                                 opacity: 0.5;
@@ -191,13 +192,14 @@ novo-form {
                                     flex: 1;
                                     position: relative;
 
-                                     > i.bhi-clock,
+                                     > i.bhi-calendar,
                                      > i.bhi-search,
                                      > i.bhi-times,
-                                    > i.bhi-calendar {
+                                    > i.bhi-clock {
                                         position: absolute;
                                         right: 0;
                                         top: 0;
+                                        font-size: 1.2em;
                                     }
 
                                     > i.bhi-times {
@@ -205,8 +207,8 @@ novo-form {
                                         font-size: 1.1em;
                                     }
 
-                                     > novo-time-picker,
-                                    > novo-date-picker {
+                                     > novo-date-picker,
+                                    > novo-time-picker {
                                         position: absolute;
                                         top: 100%;
                                         left: 0;
@@ -245,9 +247,9 @@ novo-form {
                                         padding-bottom: 0;
 
                                         &.ng-touched.ng-invalid:not(.ng-pristine) {
-                                             > input,
+                                             > input:focus,
                                              > input:hover,
-                                            > input:focus {
+                                            > input {
                                                 border-bottom-color: transparent !important;
                                             }
                                         }
@@ -323,8 +325,8 @@ novo-form {
                                                 color: rgba(0, 0, 0, .3);
                                             }
 
-                                             > h4,
-                                            > p {
+                                             > p,
+                                            > h4 {
                                                 margin: 0;
                                                 max-width: none;
                                                 padding: 0;
@@ -468,6 +470,7 @@ novo-form {
 
                         &.disabled {
                             pointer-events: none;
+
                             input {
                                 &::-webkit-input-placeholder {
                                     color: $light !important;
@@ -479,7 +482,7 @@ novo-form {
                             }
 
                             chips {
-                                border-bottom: 1px dashed $light !important;;
+                                border-bottom: 1px dashed $light !important;
 
                                 chip {
                                     opacity: 0.5;

--- a/src/elements/multi-picker/MultiPicker.js
+++ b/src/elements/multi-picker/MultiPicker.js
@@ -159,8 +159,20 @@ export class NovoMultiPickerElement extends OutsideClick {
         } else {
             this.updateItems(event, 'add');
             this.value[event.type].push(event.value);
+            let allOfType = this.getAllOfType(event.type);
+            let allOfTypeSelected = this.allItemsSelected(allOfType, event.type);
+            this.updateIndeterminateState(event.type, !allOfTypeSelected);
+            if (allOfTypeSelected) {
+                this.selectAll(allOfType, event.type);
+            }
         }
         this.select(null, event);
+    }
+
+    updateIndeterminateState(type, status) {
+        let allOfType = this.getAllOfType(type);
+        let allItem = allOfType[0];
+        allItem.indeterminate = status;
     }
 
     updateItems(item, action) {
@@ -182,7 +194,7 @@ export class NovoMultiPickerElement extends OutsideClick {
                 let count;
                 let selectedOfType = notShown.filter(x => x.type === type);
                 if (selectedOfType.length === 1 && selectedOfType[0].value === 'ALL') {
-                    count = this._options.filter(x => x.type === type)[0].data.length - 1;
+                    count = this.getAllOfType(type).length - 1;
                 } else {
                     count = selectedOfType.length;
                 }
@@ -213,6 +225,7 @@ export class NovoMultiPickerElement extends OutsideClick {
         this.value[item.type] = updatedValues;
         this.onModelChange(this.value);
         this.updateItems(item, 'remove');
+        if (this.value[item.type].length === 0) { this.updateIndeterminateState(item.type, false); }
     }
 
     onKeyDown(event) {
@@ -237,7 +250,7 @@ export class NovoMultiPickerElement extends OutsideClick {
 
     modifyAllOfType(type, action) {
         let selecting = action === 'select';
-        let allOfType = this._options.filter(x => x.type === type)[0].data;
+        let allOfType = this.getAllOfType(type);
         allOfType.forEach(item => item.checked = selecting);
         if (selecting) {
             this.selectAll(allOfType, type);
@@ -250,6 +263,7 @@ export class NovoMultiPickerElement extends OutsideClick {
     }
 
     selectAll(allOfType, type) {
+        allOfType[0].checked = true;
         let values = allOfType.map(i => { return i.value; });
         //remove 'ALL' value
         values.splice(0, 1);
@@ -261,9 +275,10 @@ export class NovoMultiPickerElement extends OutsideClick {
 
     handleRemoveItemIfAllSelected(item) {
         let type = item.type;
-        let allOfType = this._options.filter(x => x.type === type)[0].data;
+        let allOfType = this.getAllOfType(type);
         let allItem = allOfType[0];
         this.removeItem(allItem);
+
         allItem.indeterminate = true;
         let selectedItems = allOfType.filter(i => i.checked === true);
         this.items = [...this.items, ...selectedItems];
@@ -277,6 +292,10 @@ export class NovoMultiPickerElement extends OutsideClick {
             this.blur.emit(event);
             this.deselectAll(event, false);
         }
+    }
+
+    getAllOfType(type) {
+        return this._options.filter(x => x.type === type)[0].data;
     }
 
     //get accessor
@@ -302,14 +321,17 @@ export class NovoMultiPickerElement extends OutsideClick {
         if (this.types) {
             this.types.forEach(type => {
                 if (this.value[type]) {
-                    let allSelected = false;
-                    let optionsByType = this._options.filter(x => x.type === type)[0].data;
-                    if (this.value[type].length === optionsByType.length - 1) {
-                        allSelected = true;
-                        optionsByType[0].checked = true;
-                        this.updateItems(optionsByType[0], 'add');
+                    let indeterminateIsSet = false;
+                    let optionsByType = this.getAllOfType(type);
+                    let allSelected = this.allItemsSelected(optionsByType, type);
+                    if (allSelected) {
+                        this.selectAll(optionsByType, type);
                     }
                     this.value[type].forEach(item => {
+                        if (!allSelected && !indeterminateIsSet) {
+                            indeterminateIsSet = true;
+                            this.updateIndeterminateState(type, true);
+                        }
                         let value = optionsByType.filter(x => x.value === item)[0];
                         value.checked = true;
                         if (!allSelected) { this.updateItems(value, 'add'); }
@@ -319,6 +341,10 @@ export class NovoMultiPickerElement extends OutsideClick {
                 }
             });
         }
+    }
+
+    allItemsSelected(optionsByType, type) {
+        return this.value[type].length === optionsByType.length - 1;
     }
 
     // Set touched on blur

--- a/src/elements/multi-picker/MultiPicker.js
+++ b/src/elements/multi-picker/MultiPicker.js
@@ -47,7 +47,7 @@ const CHIPS_VALUE_ACCESSOR = {
             </novo-picker>
         </div>
         <i class="bhi-search"></i>
-        <label class="clear-all" *ngIf="items.length" (click)="clearValue()"><i class="bhi-times"></i> CLEAR ALL</label>
+        <label class="clear-all" *ngIf="items.length" (click)="clearValue()">CLEAR ALL <i class="bhi-times"></i></label>
    `,
     host: {
         '[class.with-value]': 'items.length > 0'

--- a/src/elements/multi-picker/MultiPicker.js
+++ b/src/elements/multi-picker/MultiPicker.js
@@ -1,0 +1,343 @@
+// NG2
+import { Component, EventEmitter, forwardRef, ElementRef } from '@angular/core';
+import { NG_VALUE_ACCESSOR } from '@angular/forms';
+// APP
+import { OutsideClick } from './../../utils/outside-click/OutsideClick';
+import { KeyCodes } from './../../utils/key-codes/KeyCodes';
+import { Helpers } from './../../utils/Helpers';
+// Vendor
+import { ReplaySubject } from 'rxjs/ReplaySubject';
+
+// Value accessor for the component (supports ngModel)
+const CHIPS_VALUE_ACCESSOR = {
+    provide: NG_VALUE_ACCESSOR,
+    useExisting: forwardRef(() => NovoMultiPickerElement),
+    multi: true
+};
+
+@Component({
+    selector: 'multi-picker',
+    inputs: ['source', 'placeholder', 'value', 'types'],
+    outputs: ['changed', 'focus', 'blur'],
+    providers: [CHIPS_VALUE_ACCESSOR],
+    template: `
+        <chip
+            *ngFor="let item of _items | async | slice:0:4"
+            [type]="type"
+            [class.selected]="item == selected"
+            (remove)="remove($event, item)"
+            (select)="select($event, item)">
+            {{ item.label }}
+        </chip>
+        <div *ngIf="items.length > 4">
+            <ul class="summary">
+                <li *ngFor="let type of notShown">+ {{type.count}} more {{type.type}}</li>
+            </ul>
+        </div>
+        <div class="chip-input-container">
+            <novo-picker
+                clearValueOnSelect="true"
+                [config]="source"
+                [placeholder]="placeholder"
+                [(ngModel)]="itemToAdd"
+                (select)="clickOption($event)"
+                (keydown)="onKeyDown($event)"
+                (focus)="onFocus($event)"
+                (blur)="onTouched($event)">
+            </novo-picker>
+        </div>
+        <i class="bhi-search"></i>
+        <label class="clear-all" *ngIf="items.length" (click)="clearValue()"><i class="bhi-times"></i> CLEAR ALL</label>
+   `,
+    host: {
+        '[class.with-value]': 'items.length > 0'
+    }
+})
+export class NovoMultiPickerElement extends OutsideClick {
+    changed:EventEmitter = new EventEmitter();
+    focus:EventEmitter = new EventEmitter();
+    blur:EventEmitter = new EventEmitter();
+    items:Array = [];
+    _items = new ReplaySubject(1);
+    selected:any = null;
+    placeholder:string = '';
+    config:Object = {};
+    // private data model
+    _value:Object = {};
+    notShown:Object = {};
+    // Placeholders for the callbacks
+    onModelChange:Function = () => {
+    };
+    onModelTouched:Function = () => {
+    };
+
+    constructor(element:ElementRef) {
+        super(element);
+        this.element = element;
+    }
+
+    ngOnInit() {
+        this.setupOptions();
+    }
+
+    clearValue() {
+        this.types.forEach(type => this.modifyAllOfType(type, 'unselect'));
+        this.items = [];
+        this._items.next(this.items);
+        this.value = this.setInitialValue(null);
+        this.onModelChange(this.value);
+    }
+
+    setupOptions() {
+        this.options = this.source.options || [];
+        this._options = [];
+        if (this.options) {
+            this.options.forEach(option => {
+                let formattedOption = this.setupOptionsByType(option);
+                this._options.push(formattedOption);
+            });
+        }
+        this.source.options = this._options;
+    }
+
+    setupOptionsByType(section) {
+        let formattedSection = {
+            type: section.type
+        };
+        formattedSection.data = section.data.map(item => {
+            return {
+                value: section.field ? item[section.field] : (item.value || item),
+                label: section.format ? Helpers.interpolate(section.format, item) : item.label || String(item.value || item),
+                type: section.type,
+                checked: undefined
+            };
+        }, this);
+        let selectAll = {
+            value: 'ALL',
+            label: `All ${section.type}`,
+            type: section.type,
+            checked: (this.model && this.model.length && (this.model.indexOf('ALL') !== -1))
+        };
+        formattedSection.data.splice(0, 0, selectAll);
+        formattedSection.originalData = formattedSection.data.slice();
+        return formattedSection;
+    }
+
+    deselectAll() {
+        this.selected = null;
+    }
+
+    select(event, item) {
+        this.blur.emit(event);
+        this.deselectAll();
+        this.selected = item;
+    }
+
+    onFocus(e) {
+        this.element.nativeElement.classList.add('selected');
+        this.focus.emit(e);
+    }
+
+    clickOption(event) {
+        if (event && !(event instanceof Event)) {
+            if (event.checked === false) {
+                this.remove(null, event);
+            } else {
+                this.add(event);
+            }
+            // Set focus on the picker
+            let input = this.element.nativeElement.querySelector('novo-picker > input');
+            if (input) {
+                input.focus();
+            }
+        }
+    }
+
+    add(event) {
+        if (event.value === 'ALL') {
+            this.modifyAllOfType(event.type, 'select');
+        } else {
+            this.updateItems(event, 'add');
+            this.value[event.type].push(event.value);
+        }
+        this.select(null, event);
+    }
+
+    updateItems(item, action) {
+        let adding = action === 'add';
+        if (adding) {
+            this.items.push(item);
+        } else {
+            if (this.items.indexOf(item) > -1) { this.items.splice(this.items.indexOf(item), 1); }
+        }
+        this.updateMoreItemsText(this.items);
+        this._items.next(this.items);
+    }
+
+    updateMoreItemsText(items) {
+        this.notShown = [];
+        let notShown = items.slice(4);
+        if (notShown.length > 0) {
+            this.types.forEach(type => {
+                let count;
+                let selectedOfType = notShown.filter(x => x.type === type);
+                if (selectedOfType.length === 1 && selectedOfType[0].value === 'ALL') {
+                    count = this._options.filter(x => x.type === type)[0].data.length - 1;
+                } else {
+                    count = selectedOfType.length;
+                }
+                let displayType = count === 1 ? type.replace(/s$/g, '') : type;
+                if (count > 0) { this.notShown.push({ type: displayType, count: count }); }
+            });
+        }
+    }
+
+    remove(event, item) {
+        if (event) {
+            event.stopPropagation();
+            event.preventDefault();
+        }
+        let itemToRemove = event || item;
+        if (itemToRemove.value === 'ALL') {
+            this.modifyAllOfType(itemToRemove.type, 'unselect');
+        } else if (this.allOfTypeSelected(itemToRemove.type)) {
+            this.handleRemoveItemIfAllSelected(itemToRemove);
+        }
+        this.removeItem(item);
+    }
+
+    removeItem(item) {
+        item.checked = false;
+        this.deselectAll();
+        let updatedValues = this.value[item.type].filter(x => x !== item.value);
+        this.value[item.type] = updatedValues;
+        this.onModelChange(this.value);
+        this.updateItems(item, 'remove');
+    }
+
+    onKeyDown(event) {
+        if (event.keyCode === KeyCodes.BACKSPACE) {
+            if (event.target && event.target.value.length === 0 && this.items.length) {
+                if (event) {
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+                if (this.selected) {
+                    this.remove(null, this.selected);
+                } else {
+                    this.select(event, this.items[this.items.length - 1]);
+                }
+            }
+        }
+    }
+
+    allOfTypeSelected(type) {
+        return this.items.filter(x => x.type === type && x.value === 'ALL').length > 0;
+    }
+
+    modifyAllOfType(type, action) {
+        let selecting = action === 'select';
+        let allOfType = this._options.filter(x => x.type === type)[0].data;
+        allOfType.forEach(item => item.checked = selecting);
+        if (selecting) {
+            this.selectAll(allOfType, type);
+        } else {
+            this.value[type] = [];
+        }
+        let updatedObject = {};
+        this.types.forEach(x => updatedObject[x] = this.value[x]);
+        this.value = updatedObject;
+    }
+
+    selectAll(allOfType, type) {
+        let values = allOfType.map(i => { return i.value; });
+        //remove 'ALL' value
+        values.splice(0, 1);
+        this.value[type] = values;
+        let updatedItems = this.items.filter(x => x.type !== type);
+        this.items = updatedItems;
+        this.updateItems(allOfType[0], 'add');
+    }
+
+    handleRemoveItemIfAllSelected(item) {
+        let type = item.type;
+        let allOfType = this._options.filter(x => x.type === type)[0].data;
+        let allItem = allOfType[0];
+        this.removeItem(allItem);
+        allItem.indeterminate = true;
+        let selectedItems = allOfType.filter(i => i.checked === true);
+        this.items = [...this.items, ...selectedItems];
+        let values = selectedItems.map(i => { return i.value; });
+        this.value[type] = [...values];
+    }
+
+    handleOutsideClick(event) {
+        // If the elements doesn't contain the target element, it is an outside click
+        if (!this.element.nativeElement.contains(event.target)) {
+            this.blur.emit(event);
+            this.deselectAll(event, false);
+        }
+    }
+
+    //get accessor
+    get value() {
+        return this._value;
+    }
+
+    //set accessor including call the onchange callback
+    set value(selectedItems) {
+        if (selectedItems) {
+            this.types.forEach(x => this._value[x] = selectedItems[x]);
+        } else {
+            this._value = {};
+            this.types.forEach(x => this._value[x] = []);
+        }
+        this.changed.emit(selectedItems);
+        this.onModelChange(selectedItems);
+    }
+
+    setInitialValue(model) {
+        this.items = [];
+        this.value = model || {};
+        if (this.types) {
+            this.types.forEach(type => {
+                if (this.value[type]) {
+                    let allSelected = false;
+                    let optionsByType = this._options.filter(x => x.type === type)[0].data;
+                    if (this.value[type].length === optionsByType.length - 1) {
+                        allSelected = true;
+                        optionsByType[0].checked = true;
+                        this.updateItems(optionsByType[0], 'add');
+                    }
+                    this.value[type].forEach(item => {
+                        let value = optionsByType.filter(x => x.value === item)[0];
+                        value.checked = true;
+                        if (!allSelected) { this.updateItems(value, 'add'); }
+                    }, this);
+                } else {
+                    this.value[type] = [];
+                }
+            });
+        }
+    }
+
+    // Set touched on blur
+    onTouched(e) {
+        this.element.nativeElement.classList.remove('selected');
+        this.onModelTouched();
+        this.blur.emit(e);
+    }
+
+    writeValue(model:any):void {
+        this.model = model;
+        this.setInitialValue(model);
+    }
+
+    registerOnChange(fn:Function):void {
+        this.onModelChange = fn;
+    }
+
+    registerOnTouched(fn:Function):void {
+        this.onModelTouched = fn;
+    }
+}

--- a/src/elements/multi-picker/MultiPicker.module.js
+++ b/src/elements/multi-picker/MultiPicker.module.js
@@ -1,0 +1,16 @@
+// NG2
+import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+// APP
+import { NovoPickerModule } from './../picker/Picker.module';
+import { NovoChipsModule } from './../chips/Chips.module';
+import { NovoMultiPickerElement } from './MultiPicker';
+
+@NgModule({
+    imports: [CommonModule, FormsModule, NovoPickerModule, NovoChipsModule],
+    declarations: [NovoMultiPickerElement],
+    exports: [NovoMultiPickerElement]
+})
+export class NovoMultiPickerModule {
+}

--- a/src/elements/multi-picker/Multipicker.spec.js
+++ b/src/elements/multi-picker/Multipicker.spec.js
@@ -1,0 +1,256 @@
+import { NovoMultiPickerElement } from './MultiPicker';
+import { APP_TEST_PROVIDERS } from './../../testing/test-providers';
+
+describe('Element: NovoMultiPickerElement', () => {
+    let component;
+
+    beforeEach(() => {
+        addProviders([
+            NovoMultiPickerElement,
+            APP_TEST_PROVIDERS
+        ]);
+    });
+
+    beforeEach(inject([NovoMultiPickerElement], _component => {
+        component = _component;
+    }));
+
+    describe('Function: ngOnInit()', () => {
+        it('should initialize properly', () => {
+            expect(component.ngOnInit).toBeDefined();
+            expect(component.clearValue).toBeDefined();
+            expect(component.setupOptions).toBeDefined();
+        });
+    });
+
+    describe('Function: clearValue()', () => {
+        it('should clear items, uncheck options, and reset value', () => {
+            component.types = ['numbers'];
+            component.items = [1, 2];
+            component.value = [1, 2];
+            component._options = [{ type: 'numbers', data: [{ value: 1, checked: true }, { value: 2, checked: false }] }];
+            component.clearValue();
+            expect(component.items.length).toBe(0);
+            expect(component.value).toEqual({ numbers: [] });
+            expect(component._options[0].data[0].checked).toBeFalsy();
+        });
+    });
+
+    describe('Function: setupOptions()', () => {
+        it('should correctly setup options', () => {
+            component.source = { options: [{ type: 'numbers', data: [1] }] };
+            component.setupOptions();
+            let data = [{ value: 'ALL', label: 'All numbers', type: 'numbers', checked: undefined }, { value: 1, label: '1', type: 'numbers', checked: undefined }];
+            let originalData = data;
+            expect(component._options).toEqual([{ type: 'numbers', data: data, originalData: originalData }]);
+            expect(component.source.options).toBe(component._options);
+        });
+    });
+
+    describe('Function: setupOptionByType(section)', () => {
+        it('should correctly format a section of options', () => {
+            let section = { type: 'cats', data: ['Kitty'] };
+            let data = [{ value: 'ALL', label: 'All cats', type: 'cats', checked: undefined }, { value: 'Kitty', label: 'Kitty', type: 'cats', checked: undefined }];
+            let expected = { type: 'cats', data: data, originalData: data };
+            let actualResult = component.setupOptionsByType(section);
+            expect(actualResult).toEqual(expected);
+        });
+    });
+
+
+    describe('Function: deselectAll()', () => {
+        it('should remove selection', () => {
+            component.selected = 'test';
+            component.deselectAll();
+            expect(component.selected).toBeFalsy();
+        });
+    });
+
+    describe('Function: select(event, item)', () => {
+        it('should select item', () => {
+            component.selected = 'before';
+            component.select(null, 'after');
+            expect(component.selected).toBe('after');
+        });
+    });
+
+    describe('Function: clickOption(event)', () => {
+        it('should remove item if checked is false', () => {
+            let item = { checked: false };
+            spyOn(component, 'remove');
+            component.clickOption(item);
+            expect(component.remove).toHaveBeenCalled();
+        });
+
+        it('should add item if checked is true', () => {
+            let item = { checked: true };
+            spyOn(component, 'add');
+            component.clickOption(item);
+            expect(component.add).toHaveBeenCalled();
+        });
+    });
+
+    describe('Function: updateItems(item, action)', () => {
+        it('should update items if adding', () => {
+            component.items = [];
+            let item = { value: 'Cat', label: 'Cat' };
+            component.updateItems(item, 'add');
+            expect(component.items.length).toBe(1);
+        });
+
+        it('should update items if removing', () => {
+            let item = { value: 'Cat', label: 'Cat' };
+            component.items = [item];
+            component.updateItems(item, 'remove');
+            expect(component.items.length).toBe(0);
+        });
+    });
+
+    describe('Function: remove(event, item)', () => {
+        it('should remove ALL item correctly', () => {
+            let item = { value: 'ALL' };
+            spyOn(component, 'modifyAllOfType');
+            spyOn(component, 'removeItem');
+            component.remove(null, item);
+            expect(component.modifyAllOfType).toHaveBeenCalled();
+            expect(component.removeItem).toHaveBeenCalled();
+        });
+
+        it('should remove normal item if ALL selected', () => {
+            component.items = [{ value: 'ALL', label: 'Cat', type: 'cats' }];
+            let itemToRemove = { value: 'Cat', label: 'Cat', type: 'cats' };
+            spyOn(component, 'handleRemoveItemIfAllSelected');
+            spyOn(component, 'removeItem');
+            component.remove(null, itemToRemove);
+            expect(component.handleRemoveItemIfAllSelected).toHaveBeenCalled();
+            expect(component.removeItem).toHaveBeenCalled();
+        });
+
+        it('should remove item normally if ALL is not selected', () => {
+            component.items = [{ value: 'Cat', label: 'Cat', type: 'cats' }];
+            let itemToRemove = { value: 'Cat', label: 'Cat', type: 'cats' };
+            spyOn(component, 'removeItem');
+            component.remove(null, itemToRemove);
+            expect(component.removeItem).toHaveBeenCalled();
+        });
+    });
+
+    describe('Function: remove(item)', () => {
+        it('should handle removing item correctly from value and items and update checked state', () => {
+            let item = { value: 'Cat', checked: true, type: 'cats' };
+            component.types = ['cats'];
+            component.items = [item, { value: 'Tiger' }];
+            component.value = { cats: ['Tiger', 'Cat'] };
+            component.removeItem(item);
+            expect(item.checked).toBeFalsy();
+            expect(component.items.length).toBe(1);
+            expect(component.value.cats).toEqual(['Tiger']);
+        });
+    });
+
+    describe('Function: updateMoreItemsText(items)', () => {
+        it('should create an object with correct type and count when count is above 2', () => {
+            let items = [{ value: 1, type: 'numbers' }, { value: 2, type: 'numbers' }, { value: 3, type: 'numbers' }, { value: 4, type: 'numbers' }, { value: 5, type: 'numbers' }, { value: 6, type: 'numbers' }];
+            component.types = ['numbers'];
+            component.updateMoreItemsText(items);
+            expect(component.notShown.length).toBe(1);
+            expect(component.notShown[0].type).toBe('numbers');
+            expect(component.notShown[0].count).toBe(2);
+        });
+        it('not add type and count to object if count is 0', () => {
+            let items = [{ value: 1, type: 'numbers' }, { value: 2, type: 'numbers' }, { value: 3, type: 'numbers' }, { value: 4, type: 'numbers' }];
+            component.types = ['numbers'];
+            component.updateMoreItemsText(items);
+            expect(component.notShown.length).toBe(0);
+        });
+        it('add all items to count if all of type is selected', () => {
+            let items = [{ value: 1, type: 'numbers' }, { value: 2, type: 'numbers' }, { value: 3, type: 'numbers' }, { value: 4, type: 'numbers' }, { value: 'ALL', type: 'cats' }];
+            component.types = ['numbers', 'cats'];
+            component._options = [{ type: 'numbers', data: [1, 2, 3, 4] }, { type: 'cats', data: ['ALL', 2, 3, 4, 5, 6, 7, 8] }];
+            component.updateMoreItemsText(items);
+            expect(component.notShown.length).toBe(1);
+            expect(component.notShown[0].type).toBe('cats');
+            expect(component.notShown[0].count).toBe(7);
+        });
+    });
+
+    describe('Function: allOfTypeSelected(type)', () => {
+        it('should return true if ALL of type is selected', () => {
+            let item = { value: 'ALL', checked: true, type: 'cats' };
+            component.items = [item];
+            expect(component.allOfTypeSelected('cats')).toBeTruthy();
+        });
+
+        it('should return false if ALL of type is not selected', () => {
+            let item = { value: 'Kitty', checked: true, type: 'cats' };
+            component.items = [item];
+            expect(component.allOfTypeSelected('cats')).toBeFalsy();
+        });
+    });
+
+    describe('Function: modifyAllOfType(type, action)', () => {
+        it('should select all if selecting', () => {
+            component.types = ['cats'];
+            component._options = [{ type: 'cats', data: [{ value: 'ALL', checked: false, type: 'cats' }, { value: 'Kitty', checked: false, type: 'cats' }] }];
+            component.value = { cats: [] };
+            component.modifyAllOfType('cats', 'select');
+            expect(component._options[0].data[0].checked).toBeTruthy();
+            expect(component._options[0].data[1].checked).toBeTruthy();
+            expect(component.value.cats).toEqual(['Kitty']);
+        });
+
+        it('should unselect all if unselecting', () => {
+            component.types = ['cats'];
+            component._options = [{ type: 'cats', data: [{ value: 'ALL', checked: false, type: 'cats' }, { value: 'Kitty', checked: true, type: 'cats' }] }];
+            component.value = { cats: [{ value: 'Kitty', checked: true, type: 'cats' }] };
+            component.modifyAllOfType('cats', 'unselect');
+            expect(component._options[0].data[1].checked).toBeFalsy();
+            expect(component.value.cats.length).toBe(0);
+        });
+    });
+
+    describe('Function: selectAll(type,)', () => {
+        it('should correctly update value and items when selecting all', () => {
+            component.types = ['cats'];
+            component._options = [{ type: 'cats', data: [{ value: 'ALL', checked: false, type: 'cats' }, { value: 'Kitty', checked: false, type: 'cats' }, { value: 'Tiger', checked: false, type: 'cats' }] }];
+            component.value = { cats: [{ value: 'Kitty', checked: false, type: 'cats' }] };
+            component.selectAll(component._options[0].data, 'cats');
+            expect(component.value.cats.length).toBe(2);
+            expect(component.items.length).toBe(1);
+            expect(component.items[0].value).toBe('ALL');
+        });
+    });
+
+    describe('Function: handleRemoveItemIfAllSelected(item)', () => {
+        it('should correctly update value and items when removing an item AND ALL is currently selected', () => {
+            component.types = ['cats'];
+            let allItem = { value: 'ALL', checked: true, type: 'cats' };
+            component._options = [{ type: 'cats', data: [allItem, { value: 'Kitty', checked: true, type: 'cats' }, { value: 'Tiger', checked: true, type: 'cats' }] }];
+            component.value = { cats: [{ value: 'ALL', checked: false, type: 'cats' }] };
+            component.items = [allItem];
+            component.handleRemoveItemIfAllSelected({ type: 'cats' });
+            expect(allItem.indeterminate).toBeTruthy();
+            expect(component.value.cats.length).toBe(2);
+            expect(component.items.length).toBe(2);
+        });
+    });
+
+    describe('Function: setInitialValue(model)', () => {
+        it('should correctly set intial value and items if a model is passed in to start', () => {
+            let model = { cats: ['Kitty'] };
+            component.types = ['cats'];
+            component._options = [{ type: 'cats', data: [{ value: 'ALL', checked: false, type: 'cats' }, { value: 'Kitty', checked: true, type: 'cats' }, { value: 'Tiger', checked: true, type: 'cats' }] }];
+            component.setInitialValue(model);
+            expect(component._options[0].data[1].checked).toBeTruthy();
+            expect(component.items.length).toBe(1);
+            expect(component.value.cats).toEqual(['Kitty']);
+        });
+        it('should correctly set intial value and items if no model is passed in to start', () => {
+            component.types = ['cats'];
+            component._options = [{ type: 'cats', data: [{ value: 'ALL', checked: false, type: 'cats' }, { value: 'Kitty', checked: true, type: 'cats' }, { value: 'Tiger', checked: true, type: 'cats' }] }];
+            component.setInitialValue(null);
+            expect(component.items).toEqual([]);
+            expect(component.value.cats).toEqual([]);
+        });
+    });
+});

--- a/src/elements/multi-picker/Multipicker.spec.js
+++ b/src/elements/multi-picker/Multipicker.spec.js
@@ -135,6 +135,30 @@ describe('Element: NovoMultiPickerElement', () => {
         });
     });
 
+    describe('Function: add(event)', () => {
+        it('should add ALL item correctly', () => {
+            let item = { value: 'ALL' };
+            spyOn(component, 'modifyAllOfType');
+            spyOn(component, 'select');
+            component.add(item);
+            expect(component.modifyAllOfType).toHaveBeenCalled();
+            expect(component.select).toHaveBeenCalled();
+        });
+
+        it('should correctly add individual item', () => {
+            component.types = ['cats'];
+            component.value = { cats: [] };
+            component._options = [{ type: 'cats', data: [{ value: 'ALL', indeterminate: undefined }, { value: 'Kitty' }, { value: 'Tiger' }] }];
+            let itemToAdd = { value: 'Cat', label: 'Cat', type: 'cats' };
+            spyOn(component, 'updateItems');
+            spyOn(component, 'updateIndeterminateState');
+            component.add(itemToAdd);
+            expect(component.updateItems).toHaveBeenCalled();
+            expect(component.updateIndeterminateState).toHaveBeenCalled();
+            expect(component.value.cats.length).toBe(1);
+        });
+    });
+
     describe('Function: remove(item)', () => {
         it('should handle removing item correctly from value and items and update checked state', () => {
             let item = { value: 'Cat', checked: true, type: 'cats' };
@@ -251,6 +275,44 @@ describe('Element: NovoMultiPickerElement', () => {
             component.setInitialValue(null);
             expect(component.items).toEqual([]);
             expect(component.value.cats).toEqual([]);
+        });
+    });
+
+    describe('Function: updateIndeterminateState(type, status)', () => {
+        it('should correctly set "ALL [type" to true', () => {
+            component.types = ['cats'];
+            component._options = [{ type: 'cats', data: [{ value: 'ALL', checked: false, type: 'cats', indeterminate: undefined }] }];
+            component.updateIndeterminateState('cats', true);
+            expect(component._options[0].data[0].indeterminate).toBeTruthy();
+        });
+        it('should correctly set "ALL [type" to false', () => {
+            component.types = ['cats'];
+            component._options = [{ type: 'cats', data: [{ value: 'ALL', checked: false, type: 'cats', indeterminate: undefined }] }];
+            component.updateIndeterminateState('cats', false);
+            expect(component._options[0].data[0].indeterminate).toBeFalsy();
+        });
+    });
+
+    describe('Function: getAllOfType(type)', () => {
+        it('should get all of type', () => {
+            component.types = ['cats'];
+            component._options = [{ type: 'cats', data: [1, 2, 3, 4] }];
+            let result = component.getAllOfType('cats');
+            expect(result.length).toBe(4);
+        });
+    });
+    describe('Function: allItemsSelected(optionsByType, type)', () => {
+        it('should return true if all individual items are selected', () => {
+            component.types = ['cats'];
+            let options = ['All', 'Kitty', 'Tiger'];
+            component.value = { cats: ['Kitty', 'Tiger'] };
+            expect(component.allItemsSelected(options, 'cats')).toBeTruthy();
+        });
+        it('should return false if all individual items are not selected', () => {
+            component.types = ['cats'];
+            let options = ['All', 'Kitty', 'Tiger'];
+            component.value = { cats: ['Kitty'] };
+            expect(component.allItemsSelected(options, 'cats')).toBeFalsy();
         });
     });
 });

--- a/src/elements/multi-picker/_MultiPicker.scss
+++ b/src/elements/multi-picker/_MultiPicker.scss
@@ -1,0 +1,80 @@
+multi-picker {
+    @extend chips;
+    @extend novo-checkbox;
+
+    .chip-input-container {
+        padding-top: 10px;
+    }
+
+    ul.summary {
+        display: inline;
+        list-style: none;
+        color: darken(#D2D2D2, 30%);
+        padding: 0 10px 0;
+
+        li {
+            display: inline;
+            padding: 0 3px;
+        }
+
+        li:after {
+            content: ", ";
+        }
+
+        li:last-child:after {
+            content: " ";
+        }
+    }
+
+    novo-picker {
+        li {
+            &.header {
+                text-transform: uppercase;
+                font-weight: 400;
+                border-top: 1px solid #e8e8e8;
+                padding-bottom: 0;
+            }
+            label {
+                color: #9e9e9e;
+                text-transform: capitalize;
+                &:hover {
+                    i {
+                        &.bhi-checkbox-empty,
+                        &.bhi-checkbox-indeterminate {
+                            color: $positive;
+                        }
+                    }
+                }
+            }
+            &.checked {
+                label {
+                    color: darken(#D2D2D2, 60%);
+
+                    i {
+                        animation: iconEnter 160ms ease-in-out;
+                    }
+                }
+            }
+        }
+        i {
+            margin-right: 5px;
+            transition: all 200ms ease-in-out;
+
+            &.bhi-checkbox-empty {
+                color: #D2D2D2;
+            }
+
+            &.bhi-checkbox-filled,
+            &.bhi-checkbox-indeterminate {
+                color: $positive;
+            }
+        }
+    }
+
+    chip {
+        span {
+            text-transform: capitalize;
+        }
+    }
+
+}

--- a/src/elements/picker/Picker.js
+++ b/src/elements/picker/Picker.js
@@ -206,6 +206,8 @@ export class NovoPickerElement extends OutsideClick {
             this._value = selected.value;
             this.select.emit(selected);
             this.onModelChange(selected.value);
+        } else {
+            this.select.emit(selected);
         }
     }
 

--- a/src/elements/picker/Picker.module.js
+++ b/src/elements/picker/Picker.module.js
@@ -8,12 +8,13 @@ import { NovoLoadingModule } from './../loading/Loading.module';
 import { NovoPickerElement } from './Picker';
 import { PickerResults } from './extras/picker-results/PickerResults';
 import { EntityPickerResults } from './extras/entity-picker-results/EntityPickerResults';
+import { ChecklistPickerResults } from './extras/checklist-picker-results/ChecklistPickerResults';
 
 @NgModule({
     imports: [CommonModule, FormsModule, NovoLoadingModule, NovoListModule],
-    declarations: [NovoPickerElement, PickerResults, EntityPickerResults],
-    exports: [NovoPickerElement, PickerResults, EntityPickerResults],
-    entryComponents: [PickerResults, EntityPickerResults]
+    declarations: [NovoPickerElement, PickerResults, EntityPickerResults, ChecklistPickerResults],
+    exports: [NovoPickerElement, PickerResults, EntityPickerResults, ChecklistPickerResults],
+    entryComponents: [PickerResults, EntityPickerResults, ChecklistPickerResults]
 })
 export class NovoPickerModule {
 }

--- a/src/elements/picker/_Picker.scss
+++ b/src/elements/picker/_Picker.scss
@@ -20,20 +20,23 @@ novo-picker {
         border: none;
         background: transparent;
         width: 100%;
+
         &:focus {
             outline: none;
         }
     }
 
-    i.bhi-search, i.bhi-times {
+    i.bhi-search,
+    i.bhi-times {
         position: absolute;
         top: 0;
         right: 0;
+        font-size: 1.2em;
     }
 
     i.bhi-times {
         cursor: pointer;
-        font-size: 1.15em;
+        font-size: 1em;
     }
 
     div.picker-results-container {
@@ -44,24 +47,24 @@ novo-picker {
     }
 }
 
-quick-note-results,
-.quick-note-results,
-picker-results,
 .picker-results,
-entity-chip-results {
+.quick-note-results,
+entity-chip-results,
+picker-results,
+quick-note-results {
     display: block;
     position: relative;
     cursor: pointer;
 }
 
-picker-results,
 .picker-results,
-quick-note-results,
 .quick-note-results,
 picker-error,
 picker-loader,
+picker-null-recent-results,
 picker-null-results,
-picker-null-recent-results {
+picker-results,
+quick-note-results {
     background-color: white;
     cursor: default;
     line-height: 26px;
@@ -78,6 +81,7 @@ picker-null-recent-results {
         list-style: none;
         padding: 0;
         margin: 0;
+
         li {
             cursor: pointer;
             padding: 10px 16px;
@@ -86,20 +90,24 @@ picker-null-recent-results {
             flex-wrap: wrap;
             flex-direction: column;
             font-size: 0.9em;
+
             span {
                 display: inline-block;
                 min-width: 100px;
                 margin: 2px 0;
             }
+
             h6 {
                 padding-top: 0;
                 font-weight: 400;
                 color: lighten($dark, 35%);
+
                 strong {
                     font-weight: 400;
                     color: $dark;
                 }
             }
+
             &.active,
             &:focus,
             &:hover {
@@ -114,15 +122,16 @@ picker-null-recent-results {
         overflow: auto;
         z-index: 1000;
     }
+
     &:focus {
         outline: none;
     }
 }
 
-picker-null-results,
-picker-null-recent-results,
 picker-error,
-picker-loader {
+picker-loader,
+picker-null-recent-results,
+picker-null-results {
     text-align: center;
     color: darken($light, 15%);
 }

--- a/src/elements/picker/extras/checklist-picker-results/ChecklistPickerResults.js
+++ b/src/elements/picker/extras/checklist-picker-results/ChecklistPickerResults.js
@@ -1,0 +1,112 @@
+// NG2
+import { Component, ElementRef } from '@angular/core';
+// APP
+import { PickerResults } from './../picker-results/PickerResults';
+import { Helpers } from './../../../../utils/Helpers';
+import { NovoLabelService } from './../../../../services/novo-label-service';
+// Vendor
+import { Observable } from 'rxjs/Rx';
+
+/**
+ * @name: ChecklistPickerResults
+ *
+ * @description This is the actual list of matches that gets injected into the DOM.
+ */
+@Component({
+    selector: 'checklist-picker-results',
+    host: {
+        'class': 'active picker-results'
+    },
+    template: `
+        <novo-loading theme="line" *ngIf="isLoading && !matches.length"></novo-loading>
+        <ul *ngIf="matches.length > 0">
+            <span *ngFor="let section of matches; let i = index">
+                <li class="header caption" *ngIf="section.data.length > 0">{{section.type}}</li>
+                <li
+                    *ngFor="let match of section.data; let i = index" [ngClass]="{checked: match.checked}"
+                    (click)="selectMatch($event, match)"
+                    [class.active]="match===activeMatch"
+                    (mouseenter)="selectActive(match)">
+                    <label>
+                        <i [ngClass]="{'bhi-checkbox-empty': !match.checked, 'bhi-checkbox-filled': match.checked, 'bhi-checkbox-indeterminate': match.indeterminate }"></i>
+                        {{match.label}}
+                    </label>
+                </li>
+            </span>
+        </ul>
+        <p class="picker-error" *ngIf="hasError">Oops! An error occured.</p>
+        <p class="picker-null" *ngIf="!isLoading && !matches.length && !hasError">No results to display...</p>
+    `
+})
+export class ChecklistPickerResults extends PickerResults {
+    constructor(element:ElementRef, labels:NovoLabelService) {
+        super(element, labels);
+    }
+
+    search() {
+        let options = this.config.options;
+        //only set this the first time
+        return Observable.fromPromise(new Promise((resolve, reject) => {
+            // Check if there is match data
+            if (options) {
+                // Resolve the data
+                if (Array.isArray(options)) {
+                    this.isStatic = true;
+                    // Arrays are returned immediately
+                    resolve(options);
+                } else {
+                    // All other kinds of data are rejected
+                    reject('The data provided is not an array or a promise');
+                    throw new Error('The data provided is not an array or a promise');
+                }
+            } else {
+                // No data gets rejected
+                reject('error');
+            }
+        }));
+    }
+    /**
+     * @name filterData=
+     * @param matches - Collection of objects=
+     *
+     * @description This function loops through the picker options and creates a filtered list of objects that contain
+     * the newSearch.
+     */
+    filterData(matches):Array {
+        if (this.term && matches) {
+            this.filteredMatches = matches.map(section => {
+                let items = section.originalData.filter((match) => {
+                    return ~String(match.label).toLowerCase().indexOf(this.term.toLowerCase());
+                });
+                section.data = items;
+                return section;
+            }, this);
+            return this.filteredMatches;
+        } else if (this.term === '') {
+            matches.forEach(section => {
+                section.data = section.originalData;
+            });
+            return matches;
+        }
+        // Show no recent results template
+        return matches;
+    }
+
+    /**
+     * @name selectMatch
+     * @param event
+     *
+     * @description
+     */
+    selectMatch(event, item) {
+        Helpers.swallowEvent(event);
+        item.checked = !item.checked;
+        if (item.indeterminate) { item.indeterminate = false; }
+
+        let selected = this.activeMatch;
+        if (selected) {
+            this.parent.value = selected;
+        }
+        return false;
+    }
+}

--- a/src/elements/picker/extras/checklist-picker-results/ChecklistPickerResults.js
+++ b/src/elements/picker/extras/checklist-picker-results/ChecklistPickerResults.js
@@ -100,8 +100,12 @@ export class ChecklistPickerResults extends PickerResults {
      */
     selectMatch(event, item) {
         Helpers.swallowEvent(event);
-        item.checked = !item.checked;
-        if (item.indeterminate) { item.indeterminate = false; }
+        if (item.indeterminate) {
+            item.indeterminate = false;
+            item.checked = true;
+        } else {
+            item.checked = !item.checked;
+        }
 
         let selected = this.activeMatch;
         if (selected) {

--- a/src/elements/table/_Table.scss
+++ b/src/elements/table/_Table.scss
@@ -31,6 +31,10 @@ novo-table {
                         margin-right: 0;
                     }
                 }
+
+                > button {
+                    height: 39px;
+                }
             }
         }
     }
@@ -41,7 +45,6 @@ novo-table {
         display: block;
     }
 }
-
 /* -- Material Design Table style -------------- */
 // Variables
 // ---------------------
@@ -63,19 +66,18 @@ $table-border-color: #f5f5f5; // Tables
     max-width: 100%;
     background-color: $table-bg;
 
-    > tbody,
-    > thead,
+     > tbody,
+     > thead,
     > tfoot {
         > tr {
-            transition: all 0.3s ease;
+            transform-style: preserve-3d;
 
-            > td,
+             > td,
             > th {
                 position: relative;
                 text-align: left;
                 padding: $table-cell-padding;
                 vertical-align: middle;
-                transition: all 0.3s ease;
 
                 &.checkbox {
                     text-align: center;
@@ -361,29 +363,29 @@ $table-border-color: #f5f5f5; // Tables
         }
     }
 }
-
 // Condensed table w/ half padding
+
 .table-condensed {
-    > tbody,
-    > thead,
+     > tbody,
+     > thead,
     > tfoot {
         > tr {
-            > td,
+             > td,
             > th {
                 padding: $table-condensed-cell-padding;
             }
         }
     }
 }
-
 // Bordered version
 // Add horizontal borders between columns.
+
 .table-bordered {
-    > tbody,
-    > thead,
+     > tbody,
+     > thead,
     > tfoot {
         > tr {
-            > td,
+             > td,
             > th {
                 border-bottom: 1px solid $table-border-color;
             }
@@ -391,29 +393,33 @@ $table-border-color: #f5f5f5; // Tables
     }
 
     > thead > tr {
-        > td,
+         > td,
         > th {
             border-bottom-width: 2px;
         }
     }
 }
-
 // Zebra-striping
 // Default zebra-stripe styles (alternating gray and transparent backgrounds)
+
 .table-striped:not(.table-details) {
     > tbody tr:nth-of-type(odd) {
         background-color: $table-bg-accent;
+
+        td {
+            background-color: $table-bg-accent;
+        }
     }
 }
 
 .table-striped.table-details {
-    > tbody tr:nth-of-type(4n+2),
+     > tbody tr:nth-of-type(4n+2),
     > tbody tr:nth-of-type(4n+1) {
         background-color: $table-bg-accent;
     }
 }
-
 // Hover effect
+
 .table-hover {
     > tbody > tr:hover {
         background-color: $table-bg-hover;
@@ -439,11 +445,15 @@ novo-table {
         .table-striped:not(.table-details) {
             > tbody tr:nth-of-type(odd) {
                 background-color: rgba($table-bg-accent, .04);
+
+                td {
+                    background-color: transparent;
+                }
             }
         }
 
         .table-striped.table-details {
-            > tbody tr:nth-of-type(4n+2),
+             > tbody tr:nth-of-type(4n+2),
             > tbody tr:nth-of-type(4n+1) {
                 background-color: rgba($table-bg-accent, .04);
             }

--- a/src/novo-elements.js
+++ b/src/novo-elements.js
@@ -29,6 +29,7 @@ export { NovoTableExtrasModule } from './elements/table/extras/TableExtras.modul
 export { NovoFormModule } from './elements/form/Form.module';
 export { NovoFormExtrasModule } from './elements/form/extras/FormExtras.module';
 export { NovoCategoryDropdownModule } from './elements/category-dropdown/CategoryDropdown.module';
+export { NovoMultiPickerModule } from './elements/multi-picker/MultiPicker.module';
 
 // Export all services
 export { NovoToastService } from './elements/toast/ToastService';
@@ -41,6 +42,7 @@ export { NovoModalParams, NovoModalRef } from './elements/modal/Modal';
 export { QuickNoteResults } from './elements/quick-note/extras/quick-note-results/QuickNoteResults';
 export { PickerResults } from './elements/picker/extras/picker-results/PickerResults';
 export { EntityPickerResults } from './elements/picker/extras/entity-picker-results/EntityPickerResults';
+export { ChecklistPickerResults } from './elements/picker/extras/checklist-picker-results/ChecklistPickerResults';
 export { BaseRenderer } from './elements/table/extras/base-renderer/BaseRenderer';
 export { DateCell } from './elements/table/extras/date-cell/DateCell';
 export { FormValidators } from './elements/form/FormValidators';

--- a/src/novo-elements.module.js
+++ b/src/novo-elements.module.js
@@ -32,6 +32,7 @@ import { NovoTableExtrasModule } from './elements/table/extras/TableExtras.modul
 import { NovoFormModule } from './elements/form/Form.module';
 import { NovoFormExtrasModule } from './elements/form/extras/FormExtras.module';
 import { NovoCategoryDropdownModule } from './elements/category-dropdown/CategoryDropdown.module';
+import { NovoMultiPickerModule } from './elements/multi-picker/MultiPicker.module';
 
 import { NovoLabelService } from './services/novo-label-service';
 import { NovoDragulaService } from './elements/dragula/DragulaService';
@@ -71,7 +72,8 @@ import { ComponentUtils } from './utils/component-utils/ComponentUtils';
         NovoTableExtrasModule,
         NovoFormModule,
         NovoFormExtrasModule,
-        NovoCategoryDropdownModule
+        NovoCategoryDropdownModule,
+        NovoMultiPickerModule
     ],
     providers: [
         { provide: ComponentUtils, useClass: ComponentUtils },

--- a/src/novo-elements.scss
+++ b/src/novo-elements.scss
@@ -47,3 +47,4 @@
 @import "./elements/tip-well/TipWell";
 @import "./elements/ckeditor/CKEditor";
 @import "./elements/category-dropdown/CategoryDropdown";
+@import "./elements/multi-picker/MultiPicker";


### PR DESCRIPTION
Address fields now show and are populated with all data except for the state field

##### **What did you change?**
I changed the address field's writeValue function to set the proper values, and formUtils to get the correct type of control for the address field.


##### **Reviewers**
* @jgodi
* @bkimball

##### **Checklist (completed via merger)**
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [contributing guide](https://github.com/bullhorn/novo-elements/blob/master/CONTRIBUTING.md)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Visually tested in supported browsers and devices